### PR TITLE
Fix missing youtube iframe on planseed page

### DIFF
--- a/planseed.html
+++ b/planseed.html
@@ -663,8 +663,8 @@
           }
           
           /* Video Section Mobile */
-          #video-cierre .pb-56\\.25 {
-            padding-bottom: 75%; /* More square on mobile */
+          #video-cierre .relative[style*="padding-bottom"] {
+            padding-bottom: 75% !important; /* More square on mobile */
           }
           
           #video-cierre .grid {
@@ -1795,7 +1795,7 @@
                     
                     <!-- Video with enhanced styling -->
                     <div class="relative rounded-2xl overflow-hidden shadow-2xl mb-8">
-                        <div class="relative pb-56.25 h-0">
+                        <div class="relative w-full" style="padding-bottom: 56.25%;">
                             <iframe 
                                 class="absolute top-0 left-0 w-full h-full" 
                                 src="https://www.youtube.com/embed/t2CnK7d69Fg?rel=0&showinfo=0&modestbranding=1" 


### PR DESCRIPTION
Fix video not appearing by correcting aspect ratio CSS and HTML structure.

The video was not appearing because `pb-56.25` was not a valid Tailwind CSS class for setting the aspect ratio. This change correctly implements the 16:9 aspect ratio for the video using an inline style and updates the CSS to ensure responsive behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-712e923f-1e54-434a-a527-ef3de2a4194b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-712e923f-1e54-434a-a527-ef3de2a4194b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>