### PR TITLE
Update pitch deck print styles

### DIFF
--- a/pitchdeck.html
+++ b/pitchdeck.html
@@ -2581,6 +2581,10 @@ padding: 1.25rem;
         box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1) !important;
     }
 
+    .grid {
+        display: grid !important; /* Forzar grid en print */
+    }
+
     /* Numeración de Páginas/Slides */
     body {
         counter-reset: page-number;


### PR DESCRIPTION
Add CSS rule to force grid display in print media for correct PDF export.

This rule was a missing piece in the robust print styles (V2) designed to resolve issues with PDF generation, specifically ensuring that grid layouts are preserved when printing the pitch deck.

---
<a href="https://cursor.com/background-agent?bcId=bc-991eb629-f5c4-41cf-9495-cb084306fa40">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-991eb629-f5c4-41cf-9495-cb084306fa40">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

