### PR TITLE
Fix pitch deck print css

### DIFF
--- a/pitchdeck.html
+++ b/pitchdeck.html
@@ -2517,9 +2517,12 @@ padding: 1.25rem;
         margin: 0;
     }
 
-    html, body {
+    html, body, * {
         -webkit-print-color-adjust: exact !important;
         print-color-adjust: exact !important;
+    }
+
+    html, body {
         background-color: #ffffff !important;
         padding: 0 !important;
         margin: 0 !important;
@@ -2544,18 +2547,22 @@ padding: 1.25rem;
     /* --- Estructura de Slides (La Clave) --- */
     main > section {
         page-break-before: always !important;
+        page-break-after: auto !important;
         page-break-inside: avoid !important;
-        width: 100vw;
-        height: 100vh;
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        align-items: center;
-        padding: 2rem !important;
-        box-sizing: border-box;
+        min-height: 100vh !important;
+        height: auto !important;
+        width: 100vw !important;
+        display: block !important;
+        padding: 40px !important;
+        box-sizing: border-box !important;
+        overflow: visible !important;
         border: none !important;
         box-shadow: none !important;
-        overflow: hidden !important;
+    }
+
+    /* First section should NOT break before */
+    main > section:first-child {
+        page-break-before: avoid !important;
     }
 
     /* --- Ajustes Finos de Contenido --- */
@@ -2568,6 +2575,12 @@ padding: 1.25rem;
     img {
         max-width: 100%;
         height: auto;
+    }
+
+    /* Chart preservation */
+    canvas, .chart-container {
+        page-break-inside: avoid !important;
+        max-width: 100% !important;
     }
 
     /* Forzar fondos e imágenes a imprimirse */
@@ -2597,14 +2610,6 @@ padding: 1.25rem;
         right: 30px;
         font-size: 12px;
         color: #94a3b8;
-    }
-    
-    /* Ajustes específicos para la primera página (Hero) */
-    #hero-team {
-        page-break-before: auto !important;
-    }
-    #hero-team::after {
-        content: ''; /* No numerar la portada */
     }
 }
 </style>


### PR DESCRIPTION
Fixes print CSS to ensure all slides print correctly.

The previous print styles had conflicting `page-break-before` rules on `#hero-team` that prevented subsequent sections from breaking onto new pages, and an empty `content` rule on `#hero-team::after` caused numbering issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-b364d734-c6d8-4ff2-862d-cffe957db3d8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b364d734-c6d8-4ff2-862d-cffe957db3d8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

