### PR TITLE
Fix pitch deck pdf printing css

### DIFF
--- a/pitchdeck.html
+++ b/pitchdeck.html
@@ -2508,108 +2508,199 @@ padding: 1.25rem;
 }
 
 /* =================================================================== */
-/* ===== ESTILOS DE IMPRESIÓN PARA PITCH DECK PDF (V2 - ROBUSTO) ======= */
+/* ===== ESTILOS DE IMPRESIÓN PARA PITCH DECK PDF (V4 - CORREGIDO) ===== */
 /* =================================================================== */
 @media print {
-    /* --- Reseteo y Configuración General de la Página --- */
+    /* --- Configuración de Página --- */
     @page {
-        size: landscape; /* Orientación horizontal */
-        margin: 0;
+        size: landscape;
+        margin: 0.5in;
     }
 
+    /* --- Forzar Impresión de Colores y Fondos --- */
     html, body, * {
         -webkit-print-color-adjust: exact !important;
         print-color-adjust: exact !important;
+        color-adjust: exact !important;
     }
 
+    /* --- Reset General --- */
     html, body {
-        background-color: #ffffff !important;
-        padding: 0 !important;
-        margin: 0 !important;
         width: 100%;
         height: 100%;
-        overflow: hidden;
+        margin: 0 !important;
+        padding: 0 !important;
+        background: #ffffff !important;
+        font-family: 'Inter', sans-serif !important;
     }
 
-    /* --- Ocultar Todos los Elementos No Deseados --- */
+    /* --- Ocultar Elementos de UI No Deseados --- */
     #desktop-nav,
     #mobile-nav,
-    footer,
     #download-pdf-button,
     .scroll-progress,
+    footer,
     .debug-info,
     .role-hint,
     [data-tooltip]::after,
     .sr-only {
         display: none !important;
+        visibility: hidden !important;
     }
 
-    /* --- Estructura de Slides (La Clave) --- */
-    main > section {
+    /* --- ESTRUCTURA DE SLIDES (LA CLAVE) --- */
+    /* Todas las secciones son slides individuales */
+    section {
         page-break-before: always !important;
         page-break-after: auto !important;
         page-break-inside: avoid !important;
-        min-height: 100vh !important;
-        height: auto !important;
-        width: 100vw !important;
-        display: block !important;
-        padding: 40px !important;
+        width: 100% !important;
+        min-height: 90vh !important;
+        display: flex !important;
+        flex-direction: column !important;
+        justify-content: center !important;
+        padding: 2rem !important;
         box-sizing: border-box !important;
+        margin: 0 !important;
+        position: relative !important;
         overflow: visible !important;
-        border: none !important;
-        box-shadow: none !important;
     }
 
-    /* First section should NOT break before */
-    main > section:first-child {
+    /* La primera sección (portada) no debe tener page-break */
+    section:first-of-type,
+    #hero-team {
         page-break-before: avoid !important;
     }
 
-    /* --- Ajustes Finos de Contenido --- */
+    /* --- Preservar Layouts y Componentes --- */
     .container {
-        max-width: 95% !important;
-        padding: 0 !important;
-        margin: 0 !important;
-    }
-    
-    img {
-        max-width: 100%;
-        height: auto;
-    }
-
-    /* Chart preservation */
-    canvas, .chart-container {
-        page-break-inside: avoid !important;
         max-width: 100% !important;
+        width: 100% !important;
+        padding: 0 !important;
+        margin: 0 auto !important;
     }
 
-    /* Forzar fondos e imágenes a imprimirse */
-    .hero-premium-enhanced, .bg-slate-100, .bg-white {
-        background-color: inherit !important;
+    /* Mantener grids funcionales */
+    .grid,
+    .grid-cols-1,
+    .grid-cols-2,
+    .grid-cols-3,
+    .grid-cols-4,
+    .md\\:grid-cols-2,
+    .md\\:grid-cols-3,
+    .md\\:grid-cols-4,
+    .lg\\:grid-cols-3,
+    .lg\\:grid-cols-4 {
+        display: grid !important;
+        gap: 1rem !important;
     }
-    
-    .card-premium, .card-premium-enforced, .kpi-card-premium-mandatory, .agent-card, .funding-card-premium-enhanced {
+
+    /* --- Preservar Cards y Componentes --- */
+    .card-premium,
+    .card-premium-enforced,
+    .kpi-card-premium-mandatory,
+    .agent-card,
+    .funding-card-premium-enhanced,
+    .esop-profile-card-premium,
+    .mvp-metric-enhanced,
+    .breakdown-item {
         page-break-inside: avoid !important;
         transform: none !important;
-        box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1) !important;
+        box-shadow: 0 2px 8px rgba(0,0,0,0.1) !important;
+        border: 1px solid #e5e7eb !important;
+        margin-bottom: 1rem !important;
     }
 
-    .grid {
-        display: grid !important; /* Forzar grid en print */
+    /* --- Preservar Charts y Canvas --- */
+    canvas,
+    .chart-container,
+    #roiChart {
+        page-break-inside: avoid !important;
+        max-width: 100% !important;
+        height: 400px !important;
+        display: block !important;
     }
 
-    /* Numeración de Páginas/Slides */
+    /* --- Preservar Iconos Lucide --- */
+    [data-lucide],
+    .lucide,
+    i[data-lucide] {
+        display: inline-block !important;
+        visibility: visible !important;
+        width: 1em !important;
+        height: 1em !important;
+    }
+
+    /* --- Ajustes de Tipografía --- */
+    h1, h2, h3, h4, h5, h6 {
+        page-break-after: avoid !important;
+        margin-bottom: 0.5rem !important;
+    }
+
+    p, li {
+        page-break-inside: avoid !important;
+        orphans: 2 !important;
+        widows: 2 !important;
+    }
+
+    /* --- Eliminar Animaciones --- */
+    *, *::before, *::after {
+        transition: none !important;
+        animation: none !important;
+        transform: none !important;
+    }
+
+    /* --- Numeración de Slides --- */
     body {
-        counter-reset: page-number;
+        counter-reset: slide-number 0;
     }
-    main > section::after {
-        counter-increment: page-number;
-        content: counter(page-number);
+
+    section::after {
+        counter-increment: slide-number;
+        content: counter(slide-number);
         position: absolute;
-        bottom: 20px;
-        right: 30px;
+        bottom: 1rem;
+        right: 1rem;
         font-size: 12px;
-        color: #94a3b8;
+        color: #64748b;
+        font-weight: 500;
+    }
+
+    /* No numerar la portada */
+    section:first-of-type::after,
+    #hero-team::after {
+        content: '' !important;
+    }
+
+    /* --- Ajustes Específicos para Fondos Gradient --- */
+    .hero-premium-enhanced,
+    .bg-gradient-premium-funding,
+    .bg-slate-100,
+    .bg-white {
+        background: #ffffff !important;
+        color: #1e293b !important;
+    }
+
+    /* Asegurar que los gradientes de texto se vean */
+    .highlight-text-premium,
+    .text-gradient-primary {
+        background: none !important;
+        color: #ea580c !important;
+        -webkit-text-fill-color: #ea580c !important;
+    }
+
+    /* --- Force Breaks en Secciones Específicas --- */
+    #team-advantage,
+    #problem-opportunity,
+    #market-size,
+    #solution-section,
+    #business-model,
+    #traction-section,
+    #technology-section,
+    #roadmap-section,
+    #financials,
+    #funding-section {
+        page-break-before: always !important;
     }
 }
 </style>


### PR DESCRIPTION
Replaces `@media print` CSS block to enable multi-slide PDF printing.

---
<a href="https://cursor.com/background-agent?bcId=bc-25708a13-2602-41b8-ba15-6b1b1985d75e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-25708a13-2602-41b8-ba15-6b1b1985d75e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

