### PR TITLE
Optimize pitchdeck print css for 14 slides

### DIFF
--- a/pitchdeck.html
+++ b/pitchdeck.html
@@ -2508,10 +2508,10 @@ padding: 1.25rem;
 }
 
 /* ================================================================ */
-/* ===== PRINT STYLES - BULLETPROOF VERSION (FINAL FIX) ========= */
+/* ===== OPTIMIZED PRINT STYLES - CLEAN 14-SLIDE PDF ============ */
 /* ================================================================ */
 @media print {
-    /* Force page setup */
+    /* Page setup */
     @page {
         size: landscape;
         margin: 0.3in;
@@ -2524,46 +2524,45 @@ padding: 1.25rem;
         color-adjust: exact !important;
     }
 
-    /* Hide navigation only */
-    nav, #desktop-nav, #mobile-nav, #download-pdf-button, .scroll-progress {
+    /* Hide navigation and UI elements */
+    nav, #desktop-nav, #mobile-nav, #download-pdf-button, .scroll-progress,
+    .mobile-nav-premium, .desktop-nav-premium {
         display: none !important;
     }
 
-    /* Remove all animations and transitions */
+    /* Remove all animations */
     *, *::before, *::after {
-        animation-duration: 0s !important;
-        animation-delay: 0s !important;
-        transition-duration: 0s !important;
-        transition-delay: 0s !important;
+        animation: none !important;
+        transition: none !important;
         transform: none !important;
     }
 
-    /* Basic page structure - EVERY section becomes a page */
+    /* Basic page structure */
     body {
         margin: 0;
         padding: 0;
         font-family: 'Inter', sans-serif !important;
-        font-size: 12pt !important;
-        line-height: 1.4 !important;
+        font-size: 11pt !important;
+        line-height: 1.3 !important;
         background: white !important;
     }
 
-    /* CRITICAL: Force each section to be a new page */
+    /* CRITICAL: Each section = one page */
     main > section,
     section {
         page-break-before: always !important;
         page-break-after: auto !important;
         page-break-inside: avoid !important;
         width: 100% !important;
-        height: auto !important;
-        min-height: 7in !important;
-        padding: 0.5in !important;
+        height: 7.5in !important;
+        padding: 0.4in !important;
         margin: 0 !important;
         box-sizing: border-box !important;
-        overflow: visible !important;
+        overflow: hidden !important;
         position: relative !important;
         background: white !important;
         display: block !important;
+        border: 1px solid #e2e8f0 !important;
     }
 
     /* First section should not break */
@@ -2572,24 +2571,72 @@ padding: 1.25rem;
         page-break-before: avoid !important;
     }
 
-    /* Force all content to be visible */
-    .container,
-    .hero-content-premium,
-    .funding-card-premium-enhanced,
-    .card-premium,
-    .card-premium-enforced,
-    .kpi-card-premium-mandatory,
-    .agent-card,
-    .esop-profile-card-premium,
-    .mvp-metric-enhanced,
-    .breakdown-item,
-    .cred-item-premium,
-    .credibility-grid-enhanced,
-    .funding-main-content,
-    .breakdown-grid,
-    .hero-ctas-enhanced,
-    .funding-timeline-premium,
-    .use-of-funds-section,
+    /* Container resets */
+    .container {
+        max-width: none !important;
+        width: 100% !important;
+        padding: 0 !important;
+        margin: 0 !important;
+    }
+
+    /* Typography */
+    h1, h2, h3, h4, h5, h6 {
+        color: #1e293b !important;
+        font-weight: bold !important;
+        margin: 0.3em 0 0.2em 0 !important;
+        page-break-after: avoid !important;
+    }
+
+    h1 { font-size: 22pt !important; }
+    h2 { font-size: 18pt !important; }
+    h3 { font-size: 15pt !important; }
+    h4 { font-size: 13pt !important; }
+
+    p, li, span {
+        color: #374151 !important;
+        font-size: 10pt !important;
+        line-height: 1.3 !important;
+        margin: 0.1em 0 !important;
+    }
+
+    /* Convert grids to columns */
+    .grid,
+    .grid-cols-1, .grid-cols-2, .grid-cols-3, .grid-cols-4,
+    .md\:grid-cols-2, .md\:grid-cols-3, .lg\:grid-cols-3, .lg\:grid-cols-4,
+    .stagger-animation, .credibility-grid-enhanced {
+        display: block !important;
+        column-count: 3 !important;
+        column-gap: 1em !important;
+        column-fill: balance !important;
+        width: 100% !important;
+    }
+
+    .grid > *, .grid-cols-2 > *, .grid-cols-3 > *, .grid-cols-4 > *,
+    .stagger-animation > *, .credibility-grid-enhanced > * {
+        display: block !important;
+        width: 100% !important;
+        margin-bottom: 0.5em !important;
+        break-inside: avoid !important;
+        page-break-inside: avoid !important;
+    }
+
+    /* Convert flex to block */
+    .flex, .hero-ctas-enhanced, .funding-amount-container, .breakdown-header {
+        display: block !important;
+        width: 100% !important;
+    }
+
+    .flex > *, .hero-ctas-enhanced > *, .funding-amount-container > *, .breakdown-header > * {
+        display: inline-block !important;
+        margin: 0.2em 0.3em 0.2em 0 !important;
+    }
+
+    /* Force all content visible */
+    .hero-content-premium, .funding-card-premium-enhanced, .card-premium,
+    .card-premium-enforced, .kpi-card-premium-mandatory, .agent-card,
+    .esop-profile-card-premium, .mvp-metric-enhanced, .breakdown-item,
+    .cred-item-premium, .funding-main-content, .breakdown-grid,
+    .funding-timeline-premium, .use-of-funds-section,
     div, p, h1, h2, h3, h4, h5, h6, span, article, aside {
         display: block !important;
         visibility: visible !important;
@@ -2599,183 +2646,97 @@ padding: 1.25rem;
         width: auto !important;
         height: auto !important;
         max-width: 100% !important;
-        page-break-inside: avoid !important;
     }
 
-    /* Typography fixes */
-    h1, h2, h3, h4, h5, h6 {
-        color: #1e293b !important;
-        font-weight: bold !important;
-        margin: 0.5em 0 0.3em 0 !important;
-        page-break-after: avoid !important;
-    }
-
-    h1 { font-size: 24pt !important; }
-    h2 { font-size: 20pt !important; }
-    h3 { font-size: 16pt !important; }
-    h4 { font-size: 14pt !important; }
-
-    p, li, span {
-        color: #374151 !important;
-        font-size: 11pt !important;
-        line-height: 1.4 !important;
-        margin: 0.2em 0 !important;
-    }
-
-    /* Grid layouts - convert to simple blocks */
-    .grid,
-    .grid-cols-1,
-    .grid-cols-2,
-    .grid-cols-3,
-    .grid-cols-4,
-    .md\:grid-cols-2,
-    .md\:grid-cols-3,
-    .lg\:grid-cols-4 {
-        display: block !important;
-        width: 100% !important;
-    }
-
-    .grid > *,
-    .grid-cols-2 > *,
-    .grid-cols-3 > *,
-    .grid-cols-4 > * {
-        display: block !important;
-        width: 100% !important;
-        margin-bottom: 1em !important;
-        page-break-inside: avoid !important;
-    }
-
-    /* Flex layouts - convert to blocks */
-    .flex,
-    .hero-ctas-enhanced,
-    .funding-amount-container,
-    .breakdown-header {
-        display: block !important;
-        width: 100% !important;
-    }
-
-    .flex > *,
-    .hero-ctas-enhanced > *,
-    .funding-amount-container > *,
-    .breakdown-header > * {
+    /* Icons */
+    [data-lucide], .lucide, i[data-lucide],
+    .kpi-icon-mandatory, .metric-icon, .breakdown-icon, .avatar-icon {
         display: inline-block !important;
-        margin: 0.2em 0.5em 0.2em 0 !important;
-    }
-
-    /* Icons and visual elements */
-    [data-lucide],
-    .lucide,
-    i[data-lucide],
-    .kpi-icon-mandatory,
-    .metric-icon,
-    .breakdown-icon,
-    .avatar-icon {
-        display: inline-block !important;
-        width: 12pt !important;
-        height: 12pt !important;
+        width: 10pt !important;
+        height: 10pt !important;
         vertical-align: middle !important;
-        margin-right: 0.3em !important;
+        margin-right: 0.2em !important;
     }
 
-    /* Metric values and KPIs */
-    .kpi-value-mandatory,
-    .metric-value-large,
-    .funding-number,
-    .breakdown-amount {
-        font-size: 18pt !important;
+    /* Metrics and values */
+    .kpi-value-mandatory, .metric-value-large, .funding-number, .breakdown-amount {
+        font-size: 16pt !important;
         font-weight: bold !important;
         color: #0d9488 !important;
         display: block !important;
-        margin: 0.3em 0 !important;
+        margin: 0.2em 0 !important;
     }
 
-    /* Charts - show placeholder */
-    canvas,
-    .chart-container,
-    #roiChart {
+    /* Charts placeholder */
+    canvas, .chart-container, #roiChart {
         display: block !important;
         width: 100% !important;
-        height: 200px !important;
+        height: 150px !important;
         border: 2px solid #e5e7eb !important;
         background: #f9fafb !important;
-        page-break-inside: avoid !important;
-    }
-
-    canvas::before,
-    .chart-container::before {
-        content: "[Gráfico: Datos financieros]" !important;
-        display: block !important;
         text-align: center !important;
-        padding: 50px !important;
-        color: #6b7280 !important;
+        line-height: 150px !important;
+        content: "[Gráfico ROI]" !important;
         font-style: italic !important;
+        color: #6b7280 !important;
     }
 
-    /* Buttons - show as text boxes */
-    .btn-primary-hero-enhanced,
-    .btn-secondary-hero-enhanced,
-    .btn-premium-mandatory,
-    a[class*="btn"] {
+    /* Buttons as text */
+    .btn-primary-hero-enhanced, .btn-secondary-hero-enhanced,
+    .btn-premium-mandatory, a[class*="btn"] {
         display: inline-block !important;
-        padding: 8pt 12pt !important;
+        padding: 4pt 8pt !important;
         border: 1pt solid #0d9488 !important;
         background: white !important;
         color: #0d9488 !important;
         text-decoration: none !important;
-        margin: 0.2em 0.5em 0.2em 0 !important;
-        font-size: 10pt !important;
+        margin: 0.1em 0.3em 0.1em 0 !important;
+        font-size: 9pt !important;
+        border-radius: 3pt !important;
     }
 
     /* Background fixes */
-    .hero-premium-enhanced,
-    .bg-slate-100,
-    .bg-gradient-premium-funding,
-    [class*="bg-"] {
+    .hero-premium-enhanced, .bg-slate-100, .bg-gradient-premium-funding,
+    [class*="bg-"], .card-premium-alert-orange, .card-premium-alert-green, .card-premium-alert-blue {
         background: white !important;
         color: #1e293b !important;
     }
 
-    /* Page numbering */
-    body {
-        counter-reset: page-counter;
-    }
-
-    section::after {
-        counter-increment: page-counter;
-        content: counter(page-counter);
-        position: absolute;
-        bottom: 0.2in;
-        right: 0.2in;
-        font-size: 10pt;
-        color: #6b7280;
-        z-index: 1000;
-    }
-
-    section:first-child::after {
-        content: '' !important;
-    }
-
-    /* Ensure container doesn't restrict content */
-    .container {
-        max-width: none !important;
-        width: 100% !important;
-        padding: 0 !important;
-        margin: 0 !important;
-    }
-
-    /* Force specific problematic elements to show */
-    .hero-title-enhanced,
-    .funding-title-premium,
-    .text-section,
-    .text-hero,
-    .highlight-text-premium,
-    .text-gradient-primary {
+    /* Force text visibility */
+    .hero-title-enhanced, .funding-title-premium, .text-section, .text-hero,
+    .highlight-text-premium, .text-gradient-primary {
         display: block !important;
         visibility: visible !important;
         color: #1e293b !important;
         background: none !important;
         -webkit-text-fill-color: #1e293b !important;
     }
+
+    /* Remove animations */
+    .fade-in-up, .stagger-animation > * {
+        opacity: 1 !important;
+        transform: none !important;
+        animation: none !important;
+    }
+
+    /* Page numbering */
+    body { counter-reset: page-counter; }
+    section::after {
+        counter-increment: page-counter;
+        content: counter(page-counter);
+        position: absolute;
+        bottom: 0.2in;
+        right: 0.2in;
+        font-size: 9pt;
+        color: #6b7280;
+        z-index: 1000;
+    }
+    section:first-child::after { content: '' !important; }
+
+    /* Specific layout fixes */
+    .funding-main-content { column-count: 2 !important; }
+    .breakdown-grid { column-count: 1 !important; }
+    .tam-sam-som-container-premium { column-count: 3 !important; }
 }
 </style>
 </head>


### PR DESCRIPTION
Replaced the print CSS to fix PDF generation, ensuring each section renders as a clean, single page for a 14-slide PDF.

---
<a href="https://cursor.com/background-agent?bcId=bc-ff614506-2a25-4ae5-8ff6-324a1405c8ee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ff614506-2a25-4ae5-8ff6-324a1405c8ee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

