### PR TITLE
Generate pitch deck pdf from frontend

### DIFF
--- a/pitchdeck.html
+++ b/pitchdeck.html
@@ -2510,233 +2510,11 @@ padding: 1.25rem;
 /* ================================================================ */
 /* ===== OPTIMIZED PRINT STYLES - CLEAN 14-SLIDE PDF ============ */
 /* ================================================================ */
+/* Simple print styles - fallback only */
 @media print {
-    /* Page setup */
-    @page {
-        size: landscape;
-        margin: 0.3in;
-    }
-
-    /* Force color printing */
-    html, body, *, *::before, *::after {
-        -webkit-print-color-adjust: exact !important;
-        print-color-adjust: exact !important;
-        color-adjust: exact !important;
-    }
-
-    /* Hide navigation and UI elements */
-    nav, #desktop-nav, #mobile-nav, #download-pdf-button, .scroll-progress,
-    .mobile-nav-premium, .desktop-nav-premium {
+    nav, #desktop-nav, #mobile-nav, #download-pdf-button, .scroll-progress {
         display: none !important;
     }
-
-    /* Remove all animations */
-    *, *::before, *::after {
-        animation: none !important;
-        transition: none !important;
-        transform: none !important;
-    }
-
-    /* Basic page structure */
-    body {
-        margin: 0;
-        padding: 0;
-        font-family: 'Inter', sans-serif !important;
-        font-size: 11pt !important;
-        line-height: 1.3 !important;
-        background: white !important;
-    }
-
-    /* CRITICAL: Each section = one page */
-    main > section,
-    section {
-        page-break-before: always !important;
-        page-break-after: auto !important;
-        page-break-inside: avoid !important;
-        width: 100% !important;
-        height: 7.5in !important;
-        padding: 0.4in !important;
-        margin: 0 !important;
-        box-sizing: border-box !important;
-        overflow: hidden !important;
-        position: relative !important;
-        background: white !important;
-        display: block !important;
-        border: 1px solid #e2e8f0 !important;
-    }
-
-    /* First section should not break */
-    section:first-child,
-    main > section:first-child {
-        page-break-before: avoid !important;
-    }
-
-    /* Container resets */
-    .container {
-        max-width: none !important;
-        width: 100% !important;
-        padding: 0 !important;
-        margin: 0 !important;
-    }
-
-    /* Typography */
-    h1, h2, h3, h4, h5, h6 {
-        color: #1e293b !important;
-        font-weight: bold !important;
-        margin: 0.3em 0 0.2em 0 !important;
-        page-break-after: avoid !important;
-    }
-
-    h1 { font-size: 22pt !important; }
-    h2 { font-size: 18pt !important; }
-    h3 { font-size: 15pt !important; }
-    h4 { font-size: 13pt !important; }
-
-    p, li, span {
-        color: #374151 !important;
-        font-size: 10pt !important;
-        line-height: 1.3 !important;
-        margin: 0.1em 0 !important;
-    }
-
-    /* Convert grids to columns */
-    .grid,
-    .grid-cols-1, .grid-cols-2, .grid-cols-3, .grid-cols-4,
-    .md\:grid-cols-2, .md\:grid-cols-3, .lg\:grid-cols-3, .lg\:grid-cols-4,
-    .stagger-animation, .credibility-grid-enhanced {
-        display: block !important;
-        column-count: 3 !important;
-        column-gap: 1em !important;
-        column-fill: balance !important;
-        width: 100% !important;
-    }
-
-    .grid > *, .grid-cols-2 > *, .grid-cols-3 > *, .grid-cols-4 > *,
-    .stagger-animation > *, .credibility-grid-enhanced > * {
-        display: block !important;
-        width: 100% !important;
-        margin-bottom: 0.5em !important;
-        break-inside: avoid !important;
-        page-break-inside: avoid !important;
-    }
-
-    /* Convert flex to block */
-    .flex, .hero-ctas-enhanced, .funding-amount-container, .breakdown-header {
-        display: block !important;
-        width: 100% !important;
-    }
-
-    .flex > *, .hero-ctas-enhanced > *, .funding-amount-container > *, .breakdown-header > * {
-        display: inline-block !important;
-        margin: 0.2em 0.3em 0.2em 0 !important;
-    }
-
-    /* Force all content visible */
-    .hero-content-premium, .funding-card-premium-enhanced, .card-premium,
-    .card-premium-enforced, .kpi-card-premium-mandatory, .agent-card,
-    .esop-profile-card-premium, .mvp-metric-enhanced, .breakdown-item,
-    .cred-item-premium, .funding-main-content, .breakdown-grid,
-    .funding-timeline-premium, .use-of-funds-section,
-    div, p, h1, h2, h3, h4, h5, h6, span, article, aside {
-        display: block !important;
-        visibility: visible !important;
-        opacity: 1 !important;
-        position: static !important;
-        overflow: visible !important;
-        width: auto !important;
-        height: auto !important;
-        max-width: 100% !important;
-    }
-
-    /* Icons */
-    [data-lucide], .lucide, i[data-lucide],
-    .kpi-icon-mandatory, .metric-icon, .breakdown-icon, .avatar-icon {
-        display: inline-block !important;
-        width: 10pt !important;
-        height: 10pt !important;
-        vertical-align: middle !important;
-        margin-right: 0.2em !important;
-    }
-
-    /* Metrics and values */
-    .kpi-value-mandatory, .metric-value-large, .funding-number, .breakdown-amount {
-        font-size: 16pt !important;
-        font-weight: bold !important;
-        color: #0d9488 !important;
-        display: block !important;
-        margin: 0.2em 0 !important;
-    }
-
-    /* Charts placeholder */
-    canvas, .chart-container, #roiChart {
-        display: block !important;
-        width: 100% !important;
-        height: 150px !important;
-        border: 2px solid #e5e7eb !important;
-        background: #f9fafb !important;
-        text-align: center !important;
-        line-height: 150px !important;
-        content: "[Gráfico ROI]" !important;
-        font-style: italic !important;
-        color: #6b7280 !important;
-    }
-
-    /* Buttons as text */
-    .btn-primary-hero-enhanced, .btn-secondary-hero-enhanced,
-    .btn-premium-mandatory, a[class*="btn"] {
-        display: inline-block !important;
-        padding: 4pt 8pt !important;
-        border: 1pt solid #0d9488 !important;
-        background: white !important;
-        color: #0d9488 !important;
-        text-decoration: none !important;
-        margin: 0.1em 0.3em 0.1em 0 !important;
-        font-size: 9pt !important;
-        border-radius: 3pt !important;
-    }
-
-    /* Background fixes */
-    .hero-premium-enhanced, .bg-slate-100, .bg-gradient-premium-funding,
-    [class*="bg-"], .card-premium-alert-orange, .card-premium-alert-green, .card-premium-alert-blue {
-        background: white !important;
-        color: #1e293b !important;
-    }
-
-    /* Force text visibility */
-    .hero-title-enhanced, .funding-title-premium, .text-section, .text-hero,
-    .highlight-text-premium, .text-gradient-primary {
-        display: block !important;
-        visibility: visible !important;
-        color: #1e293b !important;
-        background: none !important;
-        -webkit-text-fill-color: #1e293b !important;
-    }
-
-    /* Remove animations */
-    .fade-in-up, .stagger-animation > * {
-        opacity: 1 !important;
-        transform: none !important;
-        animation: none !important;
-    }
-
-    /* Page numbering */
-    body { counter-reset: page-counter; }
-    section::after {
-        counter-increment: page-counter;
-        content: counter(page-counter);
-        position: absolute;
-        bottom: 0.2in;
-        right: 0.2in;
-        font-size: 9pt;
-        color: #6b7280;
-        z-index: 1000;
-    }
-    section:first-child::after { content: '' !important; }
-
-    /* Specific layout fixes */
-    .funding-main-content { column-count: 2 !important; }
-    .breakdown-grid { column-count: 1 !important; }
-    .tam-sam-som-container-premium { column-count: 3 !important; }
 }
 </style>
 </head>
@@ -2769,7 +2547,7 @@ padding: 1.25rem;
     </nav>
 
     <!-- Botón Flotante de Descarga PDF -->
-    <button id="download-pdf-button" onclick="window.print()"
+    <button id="download-pdf-button" onclick="captureAllSlides()"
             class="fixed bottom-24 right-4 z-[9999] bg-gradient-to-br from-red-600 to-orange-500 text-white p-4 rounded-full shadow-lg hover:scale-110 transition-transform duration-300 print:hidden"
             aria-label="Descargar Blueprint como PDF"
             data-tooltip="Descargar como PDF">
@@ -3411,13 +3189,17 @@ padding: 1.25rem;
     </nav>
     
     <!-- Botón Flotante de Descarga PDF -->
-    <button id="download-pdf-button" onclick="window.print()"
+    <button id="download-pdf-button" onclick="captureAllSlides()"
             class="fixed bottom-24 right-4 z-50 bg-gradient-to-br from-red-600 to-orange-500 text-white p-4 rounded-full shadow-lg hover:scale-110 transition-transform duration-300 print:hidden"
             aria-label="Descargar Blueprint como PDF"
             data-tooltip="Descargar como PDF">
         <i data-lucide="download" class="w-6 h-6"></i>
     </button>
     
+    <!-- Add these libraries before </body> -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+
     <script>
     document.addEventListener('DOMContentLoaded', function() {
         lucide.createIcons();
@@ -3537,6 +3319,83 @@ padding: 1.25rem;
         onScroll(); // Initial check
 
     });
+
+    // Add this function in the existing script section
+    async function captureAllSlides() {
+        const sections = document.querySelectorAll('main > section');
+        const { jsPDF } = window.jspdf;
+        const pdf = new jsPDF('landscape', 'mm', 'a4');
+        
+        // Show loading indicator
+        const button = document.getElementById('download-pdf-button');
+        const originalHTML = button.innerHTML;
+        button.innerHTML = '<i data-lucide="loader-2" class="w-6 h-6 animate-spin"></i>';
+        button.disabled = true;
+        
+        // Hide navigation elements
+        const mobileNav = document.getElementById('mobile-nav');
+        const desktopNav = document.getElementById('desktop-nav');
+        const downloadBtn = document.getElementById('download-pdf-button');
+        
+        mobileNav.style.display = 'none';
+        desktopNav.style.display = 'none';
+        downloadBtn.style.display = 'none';
+        
+        try {
+            for (let i = 0; i < sections.length; i++) {
+                const section = sections[i];
+                
+                // Scroll to section
+                section.scrollIntoView({ behavior: 'auto', block: 'start' });
+                
+                // Wait for animations and content to load
+                await new Promise(resolve => setTimeout(resolve, 800));
+                
+                // Capture the section
+                const canvas = await html2canvas(section, {
+                    width: 1200,
+                    height: 850,
+                    scale: 2,
+                    useCORS: true,
+                    backgroundColor: '#ffffff',
+                    logging: false,
+                    removeContainer: true
+                });
+                
+                const imgData = canvas.toDataURL('image/png', 0.95);
+                
+                // Add page to PDF
+                if (i > 0) pdf.addPage();
+                
+                // Calculate dimensions to fit landscape A4
+                const imgWidth = 297; // A4 landscape width in mm
+                const imgHeight = 210; // A4 landscape height in mm
+                
+                pdf.addImage(imgData, 'PNG', 0, 0, imgWidth, imgHeight);
+                
+                console.log(`Captured slide ${i + 1}/${sections.length}: ${section.id || 'Section ' + (i + 1)}`);
+            }
+            
+            // Save the PDF
+            pdf.save('conductores-pitchdeck.pdf');
+            
+        } catch (error) {
+            console.error('Error generating PDF:', error);
+            alert('Error al generar el PDF. Por favor, inténtalo de nuevo.');
+        } finally {
+            // Restore navigation
+            mobileNav.style.display = 'block';
+            desktopNav.style.display = 'block';
+            downloadBtn.style.display = 'block';
+            
+            // Restore button
+            button.innerHTML = originalHTML;
+            button.disabled = false;
+            
+            // Reinitialize lucide icons
+            lucide.createIcons();
+        }
+    }
     </script>
 </body>
 </html>


### PR DESCRIPTION
Replaced print CSS with HTML2Canvas + jsPDF to generate PDFs that accurately reflect on-screen content, including animations and styling.

The previous print CSS was complex and often resulted in PDFs that did not match the live view of the pitch deck. This new solution captures each slide directly from the frontend as an image, ensuring the PDF output precisely preserves all visual elements, animations, and layout as seen by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-92b840f2-0881-4535-9b98-4cf0fd0b980a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-92b840f2-0881-4535-9b98-4cf0fd0b980a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

