### PR TITLE
Update team size in data validator

### DIFF
--- a/plan.html
+++ b/plan.html
@@ -6671,7 +6671,7 @@
           ragDNA: 150000,
           reserva: 44000,
           runway: 15,
-          teamSize: 9,
+          teamSize: 10,
           coreESOP: 3
         };
         
@@ -9017,7 +9017,7 @@
         // AGREGAR: DataValidator class
         class DataValidator {
           constructor() {
-            this.foundationalData = { totalBudget: 10000000, teamCost: 1940000 + 2340000, coreTech: 2265000, pilotCapex: 2630000, saasStack: 631000, ragDNA: 150000, reserva: 44000, runway: 15, teamSize: 9, coreESOP: 3 };
+            this.foundationalData = { totalBudget: 10000000, teamCost: 1940000 + 2340000, coreTech: 2265000, pilotCapex: 2630000, saasStack: 631000, ragDNA: 150000, reserva: 44000, runway: 15, teamSize: 10, coreESOP: 3 };
             this.tolerance = 1000; this.discrepancies = []; this.init();
           }
           init() { this.validateAll(); this.displayValidationBadge(); }


### PR DESCRIPTION
Update `teamSize` in `DataValidator` from 9 to 10 to reflect the addition of the 'Head of Growth' role and resolve validation inconsistencies.

---
<a href="https://cursor.com/background-agent?bcId=bc-a8a27f9c-d045-461d-b6d6-3ca15e57f643">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a8a27f9c-d045-461d-b6d6-3ca15e57f643">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

