### PR TITLE
Update team size in data validator

### DIFF
--- a/plan.html
+++ b/plan.html
@@ -6744,7 +6744,7 @@
         }
 
         // Validate ESOP members
-        const esopMembers = Object.keys(equipoMatrizCompleta?.roles?.filter(r => r.type === 'ESOP') || {}).length;
+        const esopMembers = (equipoMatrizCompleta?.roles?.filter(r => r.type === 'ESOP') || []).length;
         if (esopMembers !== this.foundationalData.coreESOP) {
           this.discrepancies.push({
             type: 'team',


### PR DESCRIPTION
Fixes a bug in ESOP member validation.

The previous code incorrectly used `Object.keys()` on an array and had an incorrect fallback (`|| {}` instead of `|| []`), which caused the ESOP member validation to fail despite the `teamSize` and `coreESOP` values being correct.

---
<a href="https://cursor.com/background-agent?bcId=bc-5244c94f-103c-42e5-9633-2233f1670d26">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5244c94f-103c-42e5-9633-2233f1670d26">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

