### PR TITLE
Add pitch deck pdf export functionality

### DIFF
--- a/pitchdeck.html
+++ b/pitchdeck.html
@@ -2506,6 +2506,90 @@ font-size: 1.25rem;
 padding: 1.25rem;
 }
 }
+
+/* =================================================================== */
+/* ===== ESTILOS DE IMPRESIÓN PARA PITCH DECK PDF (V3 - DEFINITIVO) ==== */
+/* =================================================================== */
+@media print {
+    /* --- Reseteo y Configuración General --- */
+    @page {
+        size: landscape;
+        margin: 0;
+    }
+
+    html, body {
+        -webkit-print-color-adjust: exact !important;
+        print-color-adjust: exact !important;
+        width: 100%;
+        height: 100%;
+        margin: 0 !important;
+        padding: 0 !important;
+        overflow: hidden;
+        background: #ffffff !important;
+    }
+
+    /* --- Ocultar Elementos No Deseados --- */
+    header, nav, footer, #download-pdf-button, .scroll-progress, .sr-only, [data-tooltip]::after {
+        display: none !important;
+    }
+
+    /* --- Estructura de Slides Universal (La Clave) --- */
+    body > section {
+        page-break-before: always !important;
+        page-break-inside: avoid !important;
+        width: 100vw;
+        height: 100vh;
+        display: flex !important;
+        flex-direction: column !important;
+        justify-content: center !important;
+        align-items: center !important;
+        padding: 2rem !important;
+        box-sizing: border-box !important;
+        border: none !important;
+        box-shadow: none !important;
+        overflow: hidden !important;
+        position: relative; /* Necesario para la numeración */
+    }
+
+    /* --- Reseteo de animaciones y transiciones --- */
+    *, *::before, *::after {
+        transition: none !important;
+        animation: none !important;
+    }
+
+    /* --- Ajustes de Contenido --- */
+    .container {
+        max-width: 95% !important;
+        padding: 0 !important;
+        margin: 0 !important;
+    }
+
+    .card-premium, .card-premium-enforced, .kpi-card-premium-mandatory, .agent-card, .funding-card-premium-enhanced {
+        transform: none !important;
+    }
+    
+    /* Numeración de Páginas/Slides */
+    body {
+        counter-reset: slide-number;
+    }
+    body > section::after {
+        counter-increment: slide-number;
+        content: counter(slide-number);
+        position: absolute;
+        bottom: 20px;
+        right: 30px;
+        font-size: 12px;
+        color: #94a3b8;
+    }
+    
+    /* Ajustes específicos para la primera página (Hero) */
+    #hero-team {
+        page-break-before: auto !important;
+    }
+    #hero-team::after {
+        content: '' !important; /* No numerar la portada */
+    }
+}
 </style>
 </head>
 <body class="bg-slate-50 text-slate-800">
@@ -2535,6 +2619,13 @@ padding: 1.25rem;
             </a>
         </div>
     </nav>
+
+<button id="download-pdf-button" onclick="window.print()"
+        class="fixed bottom-24 right-4 z-[9999] bg-gradient-to-br from-red-600 to-orange-500 text-white p-4 rounded-full shadow-lg hover:scale-110 transition-transform duration-300 print:hidden"
+        aria-label="Descargar Blueprint como PDF"
+        data-tooltip="Descargar como PDF">
+    <i data-lucide="download" class="w-6 h-6"></i>
+</button>
 
     <!-- Main Content -->
     <main>


### PR DESCRIPTION
Adds a PDF export button and print styles to `pitchdeck.html` for a front-end-only, slide-formatted PDF generation.

---
<a href="https://cursor.com/background-agent?bcId=bc-c910923d-e17e-4b8c-88f0-19f6f47de2b1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c910923d-e17e-4b8c-88f0-19f6f47de2b1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

