### PR TITLE
Debug blue screen UI rendering issue

### DIFF
--- a/integraciones.html
+++ b/integraciones.html
@@ -27,12 +27,14 @@
   <!-- 6. Your React Code (with dependencies) -->
   <script type="text/babel">
     const { useMemo, useState } = React;
-    // Make Lucide icons available from the global `lucide-react` object
+    // Make Lucide icons available from the global `lucide-react` UMD object with fallback
+    const __icons = window.LucideReact || window.lucideReact || {};
+    const FallbackIcon = (props) => React.createElement('span', { className: props.className || '' });
     const {
-      Layers, PlayCircle, ArrowRightLeft, ShieldCheck, Cable, Users, ServerCog,
-      Database, BarChart3, FileSignature, CreditCard, MessageSquare, Fuel, Bot,
-      Zap, AlertTriangle, Workflow, GitBranch
-    } = lucide;
+      Layers = FallbackIcon, PlayCircle = FallbackIcon, ArrowRightLeft = FallbackIcon, ShieldCheck = FallbackIcon, Cable = FallbackIcon, Users = FallbackIcon, ServerCog = FallbackIcon,
+      Database = FallbackIcon, BarChart3 = FallbackIcon, FileSignature = FallbackIcon, CreditCard = FallbackIcon, MessageSquare = FallbackIcon, Fuel = FallbackIcon, Bot = FallbackIcon,
+      Zap = FallbackIcon, AlertTriangle = FallbackIcon, Workflow = FallbackIcon, GitBranch = FallbackIcon
+    } = __icons;
 
     /**
      * Conductores – Arquitectura de Integraciones (Interactive Map)


### PR DESCRIPTION
Corrects Lucide icon import in `integraciones.html` to fix UI rendering issues and adds icon fallbacks.

The previous code attempted to destructure icons from a non-existent `lucide` global object, leading to a `ReferenceError` that prevented the entire UI from rendering, leaving only a blue background. This PR updates the import to use `window.LucideReact` or `window.lucideReact` and provides a `FallbackIcon` to ensure the UI displays even if icons fail to load.

---
<a href="https://cursor.com/background-agent?bcId=bc-c8be7eaa-e534-4c92-ab5b-533f22508fd6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c8be7eaa-e534-4c92-ab5b-533f22508fd6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

