### PR TITLE
Debug css rendering for integraciones.html

### DIFF
--- a/integraciones.html
+++ b/integraciones.html
@@ -719,8 +719,12 @@
     }
 
     const container = document.getElementById('root');
-    const root = ReactDOM.createRoot(container);
-    root.render(<ConductoresIntegrationsMap />);
+    if (window.ReactDOM && typeof ReactDOM.createRoot === 'function') {
+      const root = ReactDOM.createRoot(container);
+      root.render(<ConductoresIntegrationsMap />);
+    } else {
+      ReactDOM.render(<ConductoresIntegrationsMap />, container);
+    }
   </script>
 </body>
 </html>


### PR DESCRIPTION
Adjust React mounting logic in `integraciones.html` to ensure content renders when `createRoot` is unavailable.

---
<a href="https://cursor.com/background-agent?bcId=bc-638dbd5f-9a0e-4d9d-8be2-88cf044ff5dd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-638dbd5f-9a0e-4d9d-8be2-88cf044ff5dd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

