### PR TITLE
Debug blue screen on integrations page

### DIFF
--- a/integraciones.html
+++ b/integraciones.html
@@ -8,14 +8,33 @@
   <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
   <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/lucide-react/dist/esm/index.js"></script>
+
 </head>
 <body class="bg-slate-950">
   <div id="root"></div>
 
   <script type="text/babel">
     const { useMemo, useState } = React;
-    const { Layers, PlayCircle, ArrowRightLeft, ShieldCheck, Cable, Users, ServerCog, Database, BarChart3, FileSignature, CreditCard, MessageSquare, Fuel, Bot, Zap, AlertTriangle, Workflow, GitBranch } = lucide;
+    // Icon placeholders (lucide-react no UMD en navegador)
+    const PlaceholderIcon = ({ className }) => <span className={className} style={{ display: 'inline-block' }}>●</span>;
+    const Layers = (props) => <PlaceholderIcon {...props} />;
+    const PlayCircle = (props) => <PlaceholderIcon {...props} />;
+    const ArrowRightLeft = (props) => <PlaceholderIcon {...props} />;
+    const ShieldCheck = (props) => <PlaceholderIcon {...props} />;
+    const Cable = (props) => <PlaceholderIcon {...props} />;
+    const Users = (props) => <PlaceholderIcon {...props} />;
+    const ServerCog = (props) => <PlaceholderIcon {...props} />;
+    const Database = (props) => <PlaceholderIcon {...props} />;
+    const BarChart3 = (props) => <PlaceholderIcon {...props} />;
+    const FileSignature = (props) => <PlaceholderIcon {...props} />;
+    const CreditCard = (props) => <PlaceholderIcon {...props} />;
+    const MessageSquare = (props) => <PlaceholderIcon {...props} />;
+    const Fuel = (props) => <PlaceholderIcon {...props} />;
+    const Bot = (props) => <PlaceholderIcon {...props} />;
+    const Zap = (props) => <PlaceholderIcon {...props} />;
+    const AlertTriangle = (props) => <PlaceholderIcon {...props} />;
+    const Workflow = (props) => <PlaceholderIcon {...props} />;
+    const GitBranch = (props) => <PlaceholderIcon {...props} />;
 
     const LANE_WIDTH = 320;
     const LANE_GAP = 28;
@@ -412,10 +431,10 @@
         <div
           onClick={() => onSelect?.(node)}
           title={node.subtitle}
-          className={`absolute rounded-2xl border backdrop-blur px-3.5 py-3 w-[${CARD_W}px] h-[${CARD_H}px] cursor-pointer transition-all duration-200 hover:scale-[1.02] hover:shadow-xl hover:border-teal-400/50 bg-gradient-to-br ${color} ${
+          className={`absolute rounded-2xl border backdrop-blur px-3.5 py-3 cursor-pointer transition-all duration-200 hover:scale-[1.02] hover:shadow-xl hover:border-teal-400/50 bg-gradient-to-br ${color} ${
             selected ? "ring-2 ring-teal-400/70" : "ring-0"
           }`}
-          style={{ left: pos.x, top: pos.y }}
+          style={{ left: pos.x, top: pos.y, width: CARD_W, height: CARD_H }}
         >
           <div className="flex items-start gap-2">
             <div className="shrink-0 mt-0.5 text-slate-300">{node.icon}</div>


### PR DESCRIPTION
Fixes `integraciones.html` not rendering due to `lucide-react` import failure and ensures card sizing.

The "blue screen" was caused by a JavaScript error from trying to import `lucide-react` as an ESM module directly in the browser, which prevented the React application from rendering. The changes remove this problematic import, replace the icons with placeholders, and ensure card dimensions are set directly to allow the page to render correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-e19aee2f-054d-4c41-bd73-f076d1f472cc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e19aee2f-054d-4c41-bd73-f076d1f472cc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

