### PR TITLE
Fix horizontal scroll in integrations diagram

### DIFF
--- a/integraciones.html
+++ b/integraciones.html
@@ -578,7 +578,7 @@
             </aside>
 
             <main className="col-span-12 lg:col-span-9 space-y-4">
-              <div className="relative rounded-2xl border border-slate-800 bg-gradient-to-b from-slate-900 to-slate-950 overflow-hidden">
+              <div className="relative rounded-2xl border border-slate-800 bg-gradient-to-b from-slate-900 to-slate-950 overflow-x-auto overflow-y-hidden">
                 <div className="absolute inset-x-0 top-0 flex" style={{ left: PADDING_X, right: PADDING_X, height: 40 }}>
                   {LANES.map((l, idx) => (
                     visibleLanes[l.id] && (


### PR DESCRIPTION
Enable horizontal scroll for the diagram in `integraciones.html` to allow full visualization.

---
<a href="https://cursor.com/background-agent?bcId=bc-5bcdbe35-1fb9-4397-898b-31d1cad9fcec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5bcdbe35-1fb9-4397-898b-31d1cad9fcec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

