### PR TITLE
Conditionally hide sidebars and expand map view

### DIFF
--- a/integraciones.html
+++ b/integraciones.html
@@ -1537,9 +1537,10 @@
             </div>
           )}
 
-           <div className="max-w-full xl:max-w-[1800px] 2xl:max-w-[2200px] mx-auto px-6 py-6 grid grid-cols-12 gap-6">
-            <aside className="col-span-12 lg:col-span-3 space-y-4">
-              <div className="rounded-2xl border border-slate-800 bg-slate-900/40 p-4">
+                      <div className="max-w-full xl:max-w-[1800px] 2xl:max-w-[2200px] mx-auto px-6 py-6 grid grid-cols-12 gap-6">
+             {viewMode !== 'technical' && (
+             <aside className="col-span-12 lg:col-span-3 space-y-4">
+               <div className="rounded-2xl border border-slate-800 bg-slate-900/40 p-4">
                 <div className="flex items-center gap-2 mb-2">
                   <Layers className="w-4 h-4 text-slate-300" />
                   <div className="font-semibold">Capas visibles</div>
@@ -1727,9 +1728,10 @@
                   </div>
                 </div>
               )}
-            </aside>
-
-            <main className="col-span-12 lg:col-span-9 space-y-4">
+                         </aside>
+             )}
+ 
+             <main className={`col-span-12 ${viewMode === 'technical' ? 'lg:col-span-12' : 'lg:col-span-9'} space-y-4`}>
   {viewMode === 'timeline' ? (
     <>
       <div


### PR DESCRIPTION
Conditionally hide left sidebars and expand the main content area in `integraciones.html` to improve visibility and utilize full screen width for the integration map in 'Portal Tecnico' view.

---
<a href="https://cursor.com/background-agent?bcId=bc-1b9e822d-0b22-4b4e-9915-d23395208edd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1b9e822d-0b22-4b4e-9915-d23395208edd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

