### PR TITLE
Debug css bug in integraciones.html

### DIFF
--- a/integraciones.html
+++ b/integraciones.html
@@ -969,11 +969,10 @@
             <button id="zoomIn" class="px-2 py-1 rounded-lg border border-slate-700 bg-slate-800/60 hover:bg-slate-700">+</button>
             <button id="zoomOut" class="px-2 py-1 rounded-lg border border-slate-700 bg-slate-800/60 hover:bg-slate-700">-</button>
             <button id="zoomReset" class="px-2 py-1 rounded-lg border border-slate-700 bg-slate-800/60 hover:bg-slate-700">⟲</button>
-          </div>
+                    </div>
         </div>
-      </div>
 
-      <svg id="arch" viewBox="0 0 1320 760" class="w-full h-[70vh] md:h-[80vh]">
+       <svg id="arch" viewBox="0 0 1320 760" class="w-full h-[70vh] md:h-[80vh]">
         <!-- defs -->
         <defs>
           <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">


### PR DESCRIPTION
Remove extra closing div in `integraciones.html` to fix layout and rendering issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-4a9e4e70-cbad-4903-8610-d37b13ceae40">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4a9e4e70-cbad-4903-8610-d37b13ceae40">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

