### PR TITLE
Debug css for integraciones.htm blue screen

### DIFF
--- a/integraciones.html
+++ b/integraciones.html
@@ -148,7 +148,7 @@
 <body class="bg-slate-950">
   <div id="root"></div>
 
-  <script type="text/babel">
+  <script type="text/babel" data-presets="env,react">
     const { useMemo, useState, useEffect } = React;
     // Icon placeholders (lucide-react no UMD en navegador)
     const PlaceholderIcon = ({ className }) => <span className={className} style={{ display: 'inline-block' }}>●</span>;


### PR DESCRIPTION
Add Babel presets to `integraciones.html` to enable correct JSX transpilation and fix the blank screen.

The page was showing a blue screen because React components were not rendering. This was due to the `<script type="text/babel">` tag missing the `data-presets="env,react"` attribute, which is necessary for Babel to correctly transpile JSX in the browser. Adding these presets allows the React application to mount and display its content.

---
<a href="https://cursor.com/background-agent?bcId=bc-7374039f-1b47-43cd-8542-227c8fc744c1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7374039f-1b47-43cd-8542-227c8fc744c1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

