### PR TITLE
Debug script error on integraciones.html

### DIFF
--- a/integraciones.html
+++ b/integraciones.html
@@ -4,10 +4,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Arquitectura de Integraciones</title>
-  <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
-  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
-  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
-  <script src="https://cdn.tailwindcss.com"></script>
+  <script crossorigin="anonymous" src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin="anonymous" src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script crossorigin="anonymous" src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <script crossorigin="anonymous" src="https://cdn.tailwindcss.com"></script>
   <script>
     // Simple runtime error overlay for debugging
     (function(){
@@ -1449,7 +1449,7 @@
         x = vb[0];
         y = vb[1];
       }
-            svg.setAttribute('viewBox', `\${x} \${y} \${w} \${h}`);
+            svg.setAttribute('viewBox', x + ' ' + y + ' ' + w + ' ' + h);
      }
  
      // initialize larger default zoom for readability


### PR DESCRIPTION
Fix `viewBox` attribute string and add `crossorigin` to external scripts to resolve a script error and improve debugging.

The `viewBox` attribute string in `portalHTML` used nested template literals, which caused a syntax error and the reported "Script error." and blue screen. Additionally, `crossorigin="anonymous"` was added to external CDN scripts to provide more detailed error messages instead of a generic "Script error.", aiding future debugging.

---
<a href="https://cursor.com/background-agent?bcId=bc-98cb1488-3492-49b2-a05f-2425516d14ae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-98cb1488-3492-49b2-a05f-2425516d14ae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

