### PR TITLE
Fix funding engine for sinosure

### DIFF
--- a/conductores/modelofinanciero.html
+++ b/conductores/modelofinanciero.html
@@ -1427,6 +1427,12 @@ totalFunding += (plannedFinancingData[`partnerCapitalizationYear${i}`] || 0) +
 (plannedFinancingData[`commercialDebtYear${i}`] || 0) +
 (plannedFinancingData[`seriesB_newInvestors_year${i}`] || 0);
 }
+// ✅ Add Sinosure cohorts to total funding
+if (typeof sinosureCohorts !== "undefined" && sinosureCohorts.length > 0) {
+    sinosureCohorts.forEach(cohort => {
+        totalFunding += (cohort.originalAmount || 0);
+    });
+}
 return totalFunding;
 }
 /**
@@ -2347,58 +2353,26 @@ const operatingCash = netIncome + annualDepreciation + impairment + deltaProvisi
         const sourcingPlan = calculateYearlyFinancingNeeds(year, capexThisYear, operatingCash, cash, { venture: ventureDebtCohorts, commercial: commercialDebtCohorts });
         log(`💰 Sourcing Plan Year ${currentYear}: Equity=${formatCurrency(sourcingPlan.newEquity)}, VD=${formatCurrency(sourcingPlan.newVentureDebt)}, CD=${formatCurrency(sourcingPlan.newCommercialDebt)}`);
 
-        // --- SINOSURE INTEGRATION ---
+        // --- SINOSURE INTEGRATION FIX ---
         let finalNewVentureDebt = sourcingPlan.newVentureDebt;
         let finalNewCommercialDebt = sourcingPlan.newCommercialDebt;
-        
+
+        // --- SINOSURE (EXIM) INTEGRATION FIX ---
         if (modelData.sinosureAvailable && currentYear >= 2 && addedUnits > 0) {
-            // SINOSURE is deterministic - when enabled, always works
             const productionCostPerUnit = sinosureConfig.productionCostUSD * sinosureConfig.exchangeRate;
             const maxSinosureThisYear = addedUnits * productionCostPerUnit;
-            
-            // SMART SUBSTITUTION: Replace most expensive debt first
-            let remainingSinosure = maxSinosureThisYear;
-            let ventureDebtReplaced = 0;
-            let commercialDebtReplaced = 0;
-            
-            // Replace Venture Debt (18%) first - highest savings
-            if (remainingSinosure > 0 && sourcingPlan.newVentureDebt > 0) {
-                ventureDebtReplaced = Math.min(remainingSinosure, sourcingPlan.newVentureDebt);
-                finalNewVentureDebt -= ventureDebtReplaced;
-                remainingSinosure -= ventureDebtReplaced;
-            }
-            
-            // Replace Commercial Debt (14%) second
-            if (remainingSinosure > 0 && sourcingPlan.newCommercialDebt > 0) {
-                commercialDebtReplaced = Math.min(remainingSinosure, sourcingPlan.newCommercialDebt);
-                finalNewCommercialDebt -= commercialDebtReplaced;
-                remainingSinosure -= commercialDebtReplaced;
-            }
-            
-            const totalSinosureAmount = ventureDebtReplaced + commercialDebtReplaced;
-            
+
+            // Suma Sinosure como nuevo financiamiento determinístico
+            const totalSinosureAmount = maxSinosureThisYear;
             if (totalSinosureAmount > 0) {
-                // Create SINOSURE cohort at 6% rate
                 sinosureCohorts.push({
                     yearOriginated: currentYear,
                     originalAmount: totalSinosureAmount,
-                    rate: sinosureConfig.rate, // 6.0%
-                    ventureDebtReplaced: ventureDebtReplaced,
-                    commercialDebtReplaced: commercialDebtReplaced
+                    rate: sinosureConfig.rate, // 6%
+                    ventureDebtReplaced: 0,
+                    commercialDebtReplaced: 0
                 });
-                
-                // Track for financing cash flow (will be included in sinosureDrawdowns calculation)
-                
-                // Calculate annual interest savings
-                const ventureDebtSavings = ventureDebtReplaced * (modelData.ventureDebtRate - sinosureConfig.rate) / 100;
-                const commercialDebtSavings = commercialDebtReplaced * (modelData.commercialDebtRate - sinosureConfig.rate) / 100;
-                const totalAnnualSavings = ventureDebtSavings + commercialDebtSavings;
-                
-                log(`🇨🇳 SINOSURE ENABLED Year ${currentYear}:`);
-                log(`  • Amount: ${formatCurrency(totalSinosureAmount)} at 6.0%`);
-                log(`  • Replaced VD: ${formatCurrency(ventureDebtReplaced)} (18% → 6% = ${(modelData.ventureDebtRate - sinosureConfig.rate).toFixed(1)}pp savings)`);
-                log(`  • Replaced CD: ${formatCurrency(commercialDebtReplaced)} (14% → 6% = ${(modelData.commercialDebtRate - sinosureConfig.rate).toFixed(1)}pp savings)`);
-                log(`  • Annual interest savings: ${formatCurrency(totalAnnualSavings)}`);
+                log(`🇨🇳 SINOSURE Funding Year ${currentYear}: +${formatCurrency(totalSinosureAmount)} added as new capital source @ ${sinosureConfig.rate}%`);
             }
         }
 


### PR DESCRIPTION
Fix Sinosure funding logic to act as complementary capital, preventing CAPEX coverage drops.

---
<a href="https://cursor.com/background-agent?bcId=bc-e89eb49a-904e-4acc-955a-e68bdd3e908c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e89eb49a-904e-4acc-955a-e68bdd3e908c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

