### PR TITLE
Fix sinosure double counting in funding calculation

### DIFF
--- a/modelofinanciero.html
+++ b/modelofinanciero.html
@@ -1430,14 +1430,19 @@ function calculateTotalFunding() {
 let totalFunding = modelData.seriesA;
 for (let i = 1; i <= 5; i++) {
 totalFunding += (plannedFinancingData[`partnerCapitalizationYear${i}`] || 0) +
-(plannedFinancingData[`ventureDebtYear${i}`] || 0) +
-(plannedFinancingData[`commercialDebtYear${i}`] || 0) +
 (plannedFinancingData[`seriesB_newInvestors_year${i}`] || 0);
+
+// Use final debt drawdowns (post-substitution) to avoid double counting
+totalFunding += (modelData[`ventureDebtYear${i}`] || 0) +
+(modelData[`commercialDebtYear${i}`] || 0);
 }
-// Include SINOSURE cohorts created during financial calculation
+// Add only actual SINOSURE substitutions (not double-counting planned debt)
 if (typeof sinosureCohorts !== 'undefined' && Array.isArray(sinosureCohorts) && sinosureCohorts.length > 0) {
     sinosureCohorts.forEach(cohort => {
-        totalFunding += (cohort.originalAmount || 0);
+        const replacedAmount = (cohort.ventureDebtReplaced || 0) + (cohort.commercialDebtReplaced || 0);
+        if (replacedAmount > 0) {
+            totalFunding += replacedAmount;
+        }
     });
 }
 return totalFunding;


### PR DESCRIPTION
Refactor `calculateTotalFunding` to prevent double-counting SINOSURE and debt, ensuring accurate funding totals post-substitution.

The previous implementation double-counted venture/commercial debt when SINOSURE was active, as both `plannedFinancingData` and `sinosureCohorts` contributed to the same cash inflow. This change ensures debt is accounted for once (using final `modelData` values) and SINOSURE only adds the amounts that *replaced* other debt, aligning total funding with CAPEX.

---
<a href="https://cursor.com/background-agent?bcId=bc-a9b22968-3621-49bf-a27c-c5a7e344ac0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a9b22968-3621-49bf-a27c-c5a7e344ac0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

