### PR TITLE
Implement dual investor scores

### DIFF
--- a/model.html
+++ b/model.html
@@ -2360,6 +2360,50 @@ score -= 0.5;
 issues.push('📊 Leverage alto (Debt/Equity >2x)');
 }
 
+// --- Dual Investor Score: Growth vs Steady-State ---
+// Gather inputs for both modes using available model data
+const dscrFinal = calculateFinalDSCR() || 0;
+const totalFunding = calculateTotalFunding();
+const totalCapex = calculateTotalCapex();
+const coverage = totalCapex > 0 ? Math.min((totalFunding / totalCapex) * 100, 105) : 0;
+const year5BS = financialResults.bs && financialResults.bs[4] ? financialResults.bs[4] : {};
+const leverage = year5BS && year5BS.equity ? (year5BS.debt || 0) / (year5BS.equity || 1) : 0;
+const year5CF = financialResults.cf && financialResults.cf[4] ? financialResults.cf[4] : {};
+const cashAfterFin = (year5CF.netCash != null ? year5CF.netCash : ((year5CF.operatingCash || 0) + (year5CF.investingCash || 0) + (year5CF.financingCash || 0))) || 0;
+
+// Normalized Steady-State proxies (average of Y4 and Y5 where available)
+const year4CF = financialResults.cf && financialResults.cf[3] ? financialResults.cf[3] : {};
+const normalizedCFO = [year4CF.operatingCash, year5CF.operatingCash].filter(v => typeof v === 'number').length > 0
+    ? ([year4CF.operatingCash, year5CF.operatingCash].filter(v => typeof v === 'number').reduce((a,b)=>a+b,0) / [year4CF.operatingCash, year5CF.operatingCash].filter(v => typeof v === 'number').length)
+    : 0;
+const netCashY4 = (typeof year4CF.netCash === 'number') ? year4CF.netCash : ((year4CF.operatingCash || 0) + (year4CF.investingCash || 0) + (year4CF.financingCash || 0));
+const netCashY5 = (typeof year5CF.netCash === 'number') ? year5CF.netCash : ((year5CF.operatingCash || 0) + (year5CF.investingCash || 0) + (year5CF.financingCash || 0));
+const normalizedCFAF = [netCashY4, netCashY5].filter(v => typeof v === 'number').length > 0
+    ? ([netCashY4, netCashY5].filter(v => typeof v === 'number').reduce((a,b)=>a+b,0) / [netCashY4, netCashY5].filter(v => typeof v === 'number').length)
+    : 0;
+
+// Persist normalized metrics for reuse/inspection
+financialResults.normalizedCFO_Y5 = normalizedCFO;
+financialResults.normalizedCFAF_Y5 = normalizedCFAF;
+
+// Growth Mode Score
+let scoreGrowth = 10;
+if (dscrFinal < 1.5) scoreGrowth -= 2;
+if (coverage < 95 || coverage > 105) scoreGrowth -= 1;
+if (leverage > 2.0) scoreGrowth -= 1;
+if (cashAfterFin < 0) scoreGrowth -= 1;
+
+// Steady-State Score (softer penalties on DSCR/coverage; use normalized cash after financing)
+let scoreSteady = 10;
+if (dscrFinal < 1.5) scoreSteady -= 1;
+if (coverage < 95 || coverage > 105) scoreSteady -= 0.5;
+if (leverage > 2.0) scoreSteady -= 1;
+if (normalizedCFAF < 0) scoreSteady -= 0.5;
+
+financialResults.investorScoreGrowth = Math.max(scoreGrowth, 0);
+financialResults.investorScoreSteady = Math.max(scoreSteady, 0);
+log(`💹 Investor Scores => Growth: ${financialResults.investorScoreGrowth}/10 | Steady: ${financialResults.investorScoreSteady}/10`);
+
 return {
 score: Math.max(0, score),
 grade: score >= 8.5 ? 'A' : score >= 7 ? 'B' : score >= 5 ? 'C' : 'D',
@@ -3641,6 +3685,15 @@ const validations = validateModelComprehensively(modelData, financialResults);
 updateValidationPanel(validations);
 updateOptimizationStatus();
 updateInvestorScore();
+// Update inline dual score elements if present
+const growthEl = document.getElementById('investor-score-growth');
+const steadyEl = document.getElementById('investor-score-steady');
+if (growthEl) growthEl.textContent = (financialResults.investorScoreGrowth || 0).toFixed(1);
+if (steadyEl) {
+    const steady = financialResults.investorScoreSteady || 0;
+    steadyEl.textContent = steady.toFixed(1);
+    steadyEl.style.color = steady >= 8 ? "#10B981" : steady >= 6 ? "#FBBF24" : "#EF4444";
+}
 updateFundingCoverageCard();
 updateCapacityIndicator(); // Update capital capacity indicator
 
@@ -5582,16 +5635,18 @@ const gradeColor = {
 
 scoreContainer.className = `mt-4 p-4 rounded-lg border ${gradeColor}`;
 scoreContainer.innerHTML = `
-<div class="flex justify-between items-center">
-<div>
-<h3 class="font-semibold">📊 Investor Health Score</h3>
-<p class="text-sm opacity-80">Serie A Investment Readiness</p>
+<div class="flex items-center justify-between">
+  <span class="text-sm">Investor Score</span>
+  <div class="text-right">
+    <div class="text-xs text-slate-400">Growth Mode</div>
+    <div class="text-lg font-semibold text-white" id="investor-score-growth">0.0</div>
+    <div class="text-xs text-slate-400">Steady-State</div>
+    <div class="text-lg font-semibold text-teal-400" id="investor-score-steady">0.0</div>
+  </div>
 </div>
-<div class="text-right">
-<div class="text-2xl font-bold">${investorScore.score.toFixed(1)}/10</div>
-<div class="text-lg font-semibold">Grade ${investorScore.grade}</div>
-<div class="text-xs">${investorScore.isInvestable ? '✅ Investable' : '❌ Needs Work'}</div>
-</div>
+<div class="mt-2 text-right">
+  <div class="text-sm">Grade ${investorScore.grade}</div>
+  <div class="text-xs">${investorScore.isInvestable ? '✅ Investable' : '❌ Needs Work'}</div>
 </div>
 ${investorScore.issues.length > 0 ? `
 <div class="mt-3 pt-3 border-t border-white border-opacity-20">
@@ -5602,6 +5657,18 @@ ${investorScore.issues.map(issue => `<li>${issue}</li>`).join('')}
 </div>
 ` : '<div class="mt-2 text-sm">🎉 All key metrics look strong for Serie A!</div>'}
 `;
+
+// Update the dual score values and apply optional dynamic color for steady-state
+const growthScoreEl = document.getElementById('investor-score-growth');
+const steadyScoreEl = document.getElementById('investor-score-steady');
+if (growthScoreEl) {
+    growthScoreEl.textContent = (financialResults.investorScoreGrowth || 0).toFixed(1);
+}
+if (steadyScoreEl) {
+    const steady = financialResults.investorScoreSteady || 0;
+    steadyScoreEl.textContent = steady.toFixed(1);
+    steadyScoreEl.style.color = steady >= 8 ? "#10B981" : steady >= 6 ? "#FBBF24" : "#EF4444";
+}
 }
 
 // ===================================================================


### PR DESCRIPTION
Introduce dual Investor Scores (Growth and Steady-State) to provide a stable, comprehensive view of investment risk.

This change calculates both scores simultaneously, using metrics relevant to each mode, and displays them side-by-side. This prevents score fluctuations when the user toggles between growth and steady-state modes, offering a consistent narrative of risk assessment.

---
<a href="https://cursor.com/background-agent?bcId=bc-1c75184d-afa0-4e7f-9b56-5aee4ede6b5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1c75184d-afa0-4e7f-9b56-5aee4ede6b5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

